### PR TITLE
Revised import statement for scipy.integrate.trapz 

### DIFF
--- a/PyMieScatt/Inverse.py
+++ b/PyMieScatt/Inverse.py
@@ -6,7 +6,10 @@ import matplotlib.pyplot as plt
 from matplotlib.contour import QuadContourSet
 from matplotlib.collections import LineCollection
 from scipy.ndimage import zoom
-from scipy.integrate import trapz
+try:
+  from scipy.integrate import trapz
+except ImportError:
+  from scipy.integrate import trapezoid as trapz
 from shapely import geometry
 
 def coerceDType(d):

--- a/PyMieScatt/Mie.py
+++ b/PyMieScatt/Mie.py
@@ -2,7 +2,10 @@
 # http://pymiescatt.readthedocs.io/en/latest/forward.html
 import numpy as np
 from scipy.special import jv, yv
-from scipy.integrate import trapz
+try:
+  from scipy.integrate import trapz
+except ImportError:
+  from scipy.integrate import trapezoid as trapz
 import warnings
 
 def coerceDType(d):

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -189,7 +189,10 @@ Recently, a colleague needed to know how much light a distribution of salt aeros
    import PyMieScatt as ps # import PyMieScatt and abbreviate as ps
    import matplotlib.pyplot as plt # import standard plotting library and abbreviate as plt
    import numpy as np # import numpy and abbreviate as np
-   from scipy.integrate import trapz # import a single function for integration using trapezoidal rule
+   try:
+     from scipy.integrate import trapz # import a single function for integration using trapezoidal rule
+   except ImportError:
+     from scipy.integrate import trapezoid as trapz # for scipy>=1.14.0
    
    m = 1.536 # refractive index of NaCl
    wavelength = 405 # replace with the laser wavelength (nm)

--- a/docs/forward.rst
+++ b/docs/forward.rst
@@ -368,7 +368,7 @@ There is an important distinction in how the size distribution is reported from 
 
 .. py:Function:: Mie_SD(m, wavelength, sizeDistributionDiameterBins, sizeDistribution[, nMedium=1.0, SMPS=True, asDict=False])
 
-   Returns Mie coefficients β\ :sub:`ext`, β\ :sub:`sca`, β\ :sub:`abs`, G, β\ :sub:`pr`, β\ :sub:`back`, β\ :sub:`ratio`. Uses `scipy.integrate.trapz <https://docs.scipy.org/doc/scipy-0.10.1/reference/generated/scipy.integrate.trapz.html>`_ to compute the integral, which can introduce errors if your distribution is too sparse. Best used with a continuous, compactly-supported distribution.
+   Returns Mie coefficients β\ :sub:`ext`, β\ :sub:`sca`, β\ :sub:`abs`, G, β\ :sub:`pr`, β\ :sub:`back`, β\ :sub:`ratio`. Uses `scipy.integrate.trapz <https://docs.scipy.org/doc/scipy-0.10.1/reference/generated/scipy.integrate.trapz.html>`_ (or `scipy.integrate.trapezoid <https://docs.scipy.org/doc/scipy-1.14.0/reference/generated/scipy.integrate.trapezoid.html>`_ )to compute the integral, which can introduce errors if your distribution is too sparse. Best used with a continuous, compactly-supported distribution.
    
    **Parameters**
    
@@ -398,7 +398,7 @@ There is an important distinction in how the size distribution is reported from 
 
 .. py:Function:: Mie_Lognormal(m, wavelength, geoStdDev, geoMean, numberOfParticles[, nMedium=1.0, numberOfBins=1000, lower=1, upper=1000, gamma=[1], returnDistribution=False, decomposeMultimodal=False, asDict=False])
 
-   Returns Mie coefficients :math:`\beta_{ext}`, :math:`\beta_{sca}`, :math:`\beta_{abs}`, :math:`G`, :math:`\beta_{pr}`, :math:`\beta_{back}`,  and :math:`\beta_{ratio}`, integrated over a mathematically-generated k-modal lognormal particle number distribution. Uses `scipy.integrate.trapz <https://docs.scipy.org/doc/scipy-0.10.1/reference/generated/scipy.integrate.trapz.html>`_ to compute the integral.
+   Returns Mie coefficients :math:`\beta_{ext}`, :math:`\beta_{sca}`, :math:`\beta_{abs}`, :math:`G`, :math:`\beta_{pr}`, :math:`\beta_{back}`,  and :math:`\beta_{ratio}`, integrated over a mathematically-generated k-modal lognormal particle number distribution. Uses `scipy.integrate.trapz <https://docs.scipy.org/doc/scipy-0.10.1/reference/generated/scipy.integrate.trapz.html>`_ (or `scipy.integrate.trapezoid <https://docs.scipy.org/doc/scipy-1.14.0/reference/generated/scipy.integrate.trapezoid.html>`_) to compute the integral.
    
    The general form of a k-modal lognormal distribution is given by:
    


### PR DESCRIPTION
As `scipy>=1.14.0` has deprecated `scipy.integrate.trapz` in favour of `scipy.integrate.trapezoid`, we need to try to import either of them. 

Texts in `examples.rst` and `forward.rst` are also fixed to show this behaviour.